### PR TITLE
Vercel URL Bug Fix

### DIFF
--- a/apis/expenses-api-secured/index.js
+++ b/apis/expenses-api-secured/index.js
@@ -3,7 +3,28 @@ const cors = require("cors");
 const { createServer } = require("http");
 const { auth, requiredScopes } = require("express-oauth2-bearer");
 
+const {
+  NODE_ENV = "development",
+  PORT = 5000,
+  VERCEL_GITHUB_REPO,
+  VERCEL_GITHUB_ORG,
+} = process.env;
+
 const app = express();
+
+let appUrl = `http://localhost:${PORT}`;
+
+if (NODE_ENV === "production") {
+  appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
+
+  app.use((req, res, next) => {
+    const host = req.headers.host;
+    if (!appUrl.includes(host)) {
+      return res.status(301).redirect(appUrl);
+    }
+    return next();
+  });
+}
 
 app.use(cors());
 

--- a/apis/expenses-api-unsecured/index.js
+++ b/apis/expenses-api-unsecured/index.js
@@ -2,7 +2,28 @@ const express = require("express");
 const cors = require("cors");
 const { createServer } = require("http");
 
+const {
+  NODE_ENV = "development",
+  PORT = 5000,
+  VERCEL_GITHUB_REPO,
+  VERCEL_GITHUB_ORG,
+} = process.env;
+
 const app = express();
+
+let appUrl = `http://localhost:${PORT}`;
+
+if (NODE_ENV === "production") {
+  appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
+
+  app.use((req, res, next) => {
+    const host = req.headers.host;
+    if (!appUrl.includes(host)) {
+      return res.status(301).redirect(appUrl);
+    }
+    return next();
+  });
+}
 
 app.use(cors());
 

--- a/apps/front-end-spa-app-unsecured/index.html
+++ b/apps/front-end-spa-app-unsecured/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>SPA Lab</title>
+    <script type="text/javascript" src="scripts/url-check.js"></script>
     <link
       rel="shortcut icon"
       href="https://cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/favicon.png"

--- a/apps/front-end-spa-app-unsecured/scripts/url-check.js
+++ b/apps/front-end-spa-app-unsecured/scripts/url-check.js
@@ -1,5 +1,7 @@
 (function () {
-  const { NODE_ENV, VERCEL_GITHUB_REPO, VERCEL_GITHUB_ORG } = process.env;
+  const NODE_ENV = process.env.NODE_ENV;
+  const VERCEL_GITHUB_ORG = process.env.VERCEL_GITHUB_ORG;
+  const VERCEL_GITHUB_REPO = process.env.VERCEL_GITHUB_REPO;
 
   if (NODE_ENV === "production") {
     const appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;

--- a/apps/front-end-spa-app-unsecured/scripts/url-check.js
+++ b/apps/front-end-spa-app-unsecured/scripts/url-check.js
@@ -1,0 +1,11 @@
+(function () {
+  const { NODE_ENV, VERCEL_GITHUB_REPO, VERCEL_GITHUB_ORG } = process.env;
+
+  if (NODE_ENV === "production") {
+    const appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
+
+    if (!appUrl.includes(window.location.host)) {
+      window.location = appUrl;
+    }
+  }
+})();

--- a/apps/front-end-web-app-secured/index.js
+++ b/apps/front-end-web-app-secured/index.js
@@ -14,17 +14,25 @@ const {
   VERCEL_GITHUB_ORG,
 } = process.env;
 
-let appUrl = `http://localhost:${PORT}`;
-
-if (NODE_ENV === "production") {
-  appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
-}
-
 const app = express();
 
 app.set("view engine", "ejs");
 
 app.use(morgan("combined"));
+
+let appUrl = `http://localhost:${PORT}`;
+
+if (NODE_ENV === "production") {
+  appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
+
+  app.use((req, res, next) => {
+    const host = req.headers.host;
+    if (!appUrl.includes(host)) {
+      return res.status(301).redirect(appUrl);
+    }
+    return next();
+  });
+}
 
 app.use(
   session({

--- a/apps/web-app-unsecured/index.js
+++ b/apps/web-app-unsecured/index.js
@@ -2,12 +2,34 @@ const express = require("express");
 const { createServer } = require("http");
 const morgan = require("morgan");
 
-const { NODE_ENV = "development", PORT = 7000 } = process.env;
+const {
+  NODE_ENV = "development",
+  PORT = 7000,
+  API_URL,
+  SESSION_SECRET,
+  VERCEL_GITHUB_REPO,
+  VERCEL_GITHUB_ORG,
+} = process.env;
 
 const app = express();
 
 app.set("view engine", "ejs");
+
 app.use(morgan("combined"));
+
+let appUrl = `http://localhost:${PORT}`;
+
+if (NODE_ENV === "production") {
+  appUrl = `https://${VERCEL_GITHUB_REPO}.${VERCEL_GITHUB_ORG.toLowerCase()}.vercel.app`;
+
+  app.use((req, res, next) => {
+    const host = req.headers.host;
+    if (!appUrl.includes(host)) {
+      return res.status(301).redirect(appUrl);
+    }
+    return next();
+  });
+}
 
 app.get("/", (req, res) => {
   res.render("home", { user: req.openid && req.openid.user });


### PR DESCRIPTION
Each deployment to Vercel is assigned a unique immutable deployment URL. It is then aliased to a production URL that is based on the Vercel project name. If a project already exists on Vercel with a given project name, the production URL will have appended random text to make it unique.

This causes a problem when attempting to configure some settings like `baseURL` in the `express-openid-connect` node module. For example, you may start on the production url of **https://myapp.vercel.app**, login using Auth0 and be retured to a completely different url of **https://myapp-sdfsdf.vercel.app**.

To avoid this situation, these example applications attempt to use another option for the **baseURL** value that contains both the **VERCEL_GITHUB_REPO** and **VERCEL_GITHUB_ORG** environment variables.

This PR adds a check to the current url and redirects to the one we expect. The url format is:

```
https://VERCEL_GITHUB_REPO.VERCEL_GITHUB_ORG.vercel.app
```

## Testing:

#### Expenses API Unsecured

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fauth0%2Fauth0-product-education-labs%2Ftree%2Fvercel-url-fix%2Fapis%2Fexpenses-api-unsecured&env=ISSUER_BASE_URL,ALLOWED_AUDIENCES,NODE_ENV,VERCEL_URL,VERCEL_GITHUB_REPO,VERCEL_GITHUB_ORG&project-name=expenses-api-unsecured&repository-name=expenses-api-unsecured)

- [x] Can run locally
- [x] Can deploy to Vercel
- [x] Vercel redirects to the correct url format 

#### Expenses API Secured

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fauth0%2Fauth0-product-education-labs%2Ftree%2Fvercel-url-fix%2Fapis%2Fexpenses-api-secured&env=ISSUER_BASE_URL,ALLOWED_AUDIENCES,NODE_ENV,VERCEL_URL,VERCEL_GITHUB_REPO,VERCEL_GITHUB_ORG&project-name=expenses-api-secured&repository-name=expenses-api-secured)

- [x] Can run locally
- [x] Can deploy to Vercel
- [x] Vercel redirects to the correct url format

#### Web App Unsecured

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fauth0%2Fauth0-product-education-labs%2Ftree%2Fvercel-url-fix%2Fapps%2Fweb-app-unsecured&env=ISSUER_BASE_URL,CLIENT_ID,APP_SESSION_SECRET,NODE_ENV,VERCEL_URL,VERCEL_GITHUB_REPO,VERCEL_GITHUB_ORG&project-name=web-app-unsecured&repository-name=web-app-unsecured)

- [x] Can run locally
- [x] Can deploy to Vercel
- [x] Vercel redirects to the correct url format

#### Front End Web App Secured

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fauth0%2Fauth0-product-education-labs%2Ftree%2Fvercel-url-fix%2Fapps%2Ffront-end-web-app-secured&env=ISSUER_BASE_URL,CLIENT_ID,SESSION_SECRET,API_URL,NODE_ENV,VERCEL_URL,VERCEL_GITHUB_REPO,VERCEL_GITHUB_ORG&project-name=front-end-web-app-secured&repository-name=front-end-web-app-secured)

- [x] Can run locally
- [x] Can deploy to Vercel
- [x] Vercel redirects to the correct url format

#### Front End SPA App Unsecured

[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fauth0%2Fauth0-product-education-labs%2Ftree%2Fvercel-url-fix%2Fapps%2Ffront-end-spa-app-unsecured&env=AUTH0_DOMAIN,CLIENT_ID,API_URL,NODE_ENV,VERCEL_URL,VERCEL_GITHUB_REPO,VERCEL_GITHUB_ORG&project-name=front-end-spa-app-unsecured&repository-name=front-end-spa-app-unsecured)

- [x] Can run locally
- [x] Can deploy to Vercel
- [x] Vercel redirects to the correct url format